### PR TITLE
fix: playlist-detail api can't get all tracks , update source api

### DIFF
--- a/router/playlist_detail.js
+++ b/router/playlist_detail.js
@@ -12,7 +12,7 @@ router.get("/", (req, res) => {
 
   createWebAPIRequest(
     "music.163.com",
-    "/weapi/v3/playlist/detail",
+    `/api/playlist/detail?id=${req.query.id}`,
     "POST",
     data,
     cookie,


### PR DESCRIPTION
我发现了获取歌单详情似乎出现了问题，在获取到的数据内tracks内部最多只有10首歌，然后有一个trackIds的数组，其数量虽然完整，但内部只有两个信息，一个歌曲的ID，还有一个不知道什么东西。

![](https://ws1.sinaimg.cn/large/0061RWEnly1fnr2m3lm8lj30kb01j0sq.jpg)

```js
"trackIds": [
  {
  "id": 28283308,
  "v": 10
  },
  // 整体长度正常但是信息缺失
]
```
于是我寻找到了这个看上去挺老的接口 不过可以正常工作

![](https://ws1.sinaimg.cn/large/0061RWEnly1fnr2ogdhcyj30jr00x745.jpg)

另外对node的request模块不是很熟悉，不知道为啥换成get回复参数不正确，就干脆暴力的在路径后面加query了
