### PR TITLE
banner接口修改

### DIFF
--- a/router/banner.js
+++ b/router/banner.js
@@ -19,7 +19,7 @@ router.get("/", (req, res) => {
       try {
         const pattern = /<script[^>]*>\s*window\.Gbanners\s*=\s*([^;]+?);\s*<\/script>/g;
         const banners = pattern.exec(body)[1];
-        res.send(JSON.stringify(eval(banners)));
+        res.send(JSON.stringify(eval(`({code:200,banners:${banners}})`)));
       } catch (error) {
         res.status(502).send("fetch error");
       }

--- a/router/banner.js
+++ b/router/banner.js
@@ -1,24 +1,30 @@
 const express = require("express");
 const router = express();
-const { createWebAPIRequest } = require("../util/util");
+const request = require("request");
 
 router.get("/", (req, res) => {
-  const cookie = req.get("Cookie") ? req.get("Cookie") : "";
-  const data = {
-    timeStamp: 0 + new Date(),
-    csrf_token: ""
+  const options = {
+    url: "http://music.163.com/discover",
+    method: "GET",
+    headers: {
+      Referer: "http://music.163.com",
+      "User-Agent":
+        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/67.0.3380.0 Safari/537.36"
+    }
   };
-  createWebAPIRequest(
-    "music.163.com",
-    "/api/v2/banner/get",
-    "POST",
-    data,
-    cookie,
-    music_req => {
-      res.send(music_req);
-    },
-    err => res.status(502).send("fetch error")
-  );
+  request(options, (error, response, body) => {
+    if (error) {
+      res.status(502).send("fetch error");
+    } else {
+      try {
+        const pattern = /<script[^>]*>\s*window\.Gbanners\s*=\s*([^;]+?);\s*<\/script>/g;
+        const banners = pattern.exec(body)[1];
+        res.send(JSON.stringify(eval(banners)));
+      } catch (error) {
+        res.status(502).send("fetch error");
+      }
+    }
+  });
 });
 
 module.exports = router;


### PR DESCRIPTION
## 关于
对于第三方客户端的项目，banner接口还是非常重要的
然而v2.8.0(用request重写请求)更新中给banner接口随缘增加参数绝对是不行的😂

## 实现
从`/discover`页取数据的神奇操作
来源于[pureliumy/NeteaseMusicBanner](https://github.com/pureliumy/NeteaseMusicBanner)
我将提取的过程换用正则做了

## Q&A
Q: 为什么不用`util.js`里封装好的`createRequest`
A: 因为`randomUserAgent`如果取到移动端UA会重定向到M站，获取不到数据

Q: 为什么等人找参数PR不现实
A: 请求都走网页版weapi，然而banner的旧接口是客户端api。用weapi的加密方式去请求，再怎么改参数也没有意义啊。且现在客户端都走eapi接口，去逆向旧接口的价值不大

Q: 为什么我一直没PR
A: 因为这样改有缺陷，网页版的banner的尺寸(730x336)，而且不是专辑封面那样可以带`?param=`来控制尺寸的，与旧接口相比小一圈，也请作者权衡后merge