### PR TITLE
fix: 手机登陆异常

### DIFF
--- a/app.js
+++ b/app.js
@@ -45,7 +45,7 @@ const { createWebAPIRequest, request } = require("./util/util");
 const Wrap = fn => (req, res) => fn(req, res, createWebAPIRequest, request);
 
 // 同步读取 router 目录中的js文件, 根据命名规则, 自动注册路由
-fs.readdirSync("./router/").forEach(file => {
+fs.readdirSync("./router/").reverse().forEach(file => {
   if (/\.js$/i.test(file) === false) {
     return;
   }


### PR DESCRIPTION
`fs` 读取目录获得的文件名数组， `login.js` 排在 `loginCellphone.js` 前面
所以会先注册 `/login` 这个路径，导致后面注册的 `login/cellphone` 无法被正确处理