### PR TITLE
使用绝对路径读取路由文件注册

### DIFF
--- a/app.js
+++ b/app.js
@@ -45,7 +45,7 @@ const { createWebAPIRequest, request } = require("./util/util");
 const Wrap = fn => (req, res) => fn(req, res, createWebAPIRequest, request);
 
 // 同步读取 router 目录中的js文件, 根据命名规则, 自动注册路由
-fs.readdirSync("./router/").reverse().forEach(file => {
+fs.readdirSync(path.resolve(__dirname, "router")).reverse().forEach(file => {
   if (/\.js$/i.test(file) === false) {
     return;
   }


### PR DESCRIPTION
使用相对路径会导致在非项目根目录执行 app.js 会报错, 例如在项目目录外一层执行 `node NeteaseCloudMusicApi/app.js`

```
Error: ENOENT: no such file or directory, scandir './router/'
```
所以改用绝对路径