### PR TITLE
Remove npmview dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ node_modules
 
 .idea/
 package-lock.json
+
+.vscode

--- a/app.js
+++ b/app.js
@@ -4,23 +4,25 @@ const path = require('path')
 const fs = require('fs')
 const app = express()
 let cache = apicache.middleware
-var npmview = require('npmview')
-npmview('NeteaseCloudMusicApi', function(err, version, moduleInfo) {
+const { exec } = require('child_process');
+exec('npm info NeteaseCloudMusicApi version', (err, stdout, stderr) => {
   if (err) {
-    console.error(err)
-    return
+    console.error(err);
+    return;
   }
+  const onlinePackageVersion = stdout.trim();
   const package = require('./package.json')
-  if (package.version < version) {
+  if (package.version < onlinePackageVersion) {
     console.log(
       '最新版:Version:' +
-        version +
+      onlinePackageVersion +
         ',当前版本:' +
         package.version +
         ',请及时更新'
     )
   }
 })
+
 // 跨域设置
 app.all('*', function(req, res, next) {
   if (req.path !== '/' && !req.path.includes('.')) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "NeteaseCloudMusicApi",
-  "version": "2.19.0",
+  "version": "2.20.0",
   "description": "网易云音乐 NodeJS 版 API",
   "scripts": {
     "start": "node app.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "NeteaseCloudMusicApi",
-  "version": "2.20.0",
+  "version": "2.19.0",
   "description": "网易云音乐 NodeJS 版 API",
   "scripts": {
     "start": "node app.js",
@@ -18,8 +18,7 @@
     "apicache": "^1.2.1",
     "big-integer": "^1.6.28",
     "express": "^4.16.3",
-    "request": "^2.85.0",
-    "npmview": "^0.0.4"
+    "request": "^2.85.0"
   },
   "devDependencies": {
     "intelli-espower-loader": "^1.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1343,15 +1343,6 @@ npmlog@0.0.6:
   dependencies:
     ansi "~0.2.1"
 
-npmview@^0.0.4:
-  version "0.0.4"
-  resolved "http://r.cnpmjs.org/npmview/download/npmview-0.0.4.tgz#1ecc0a4e0e604422eacb2575f4e19e9f776ed9ce"
-  dependencies:
-    async-err "0.0.2"
-    have "0.2.3"
-    npm "1.3.26"
-    semver "2.2.1"
-
 number-is-nan@^1.0.0:
   version "1.0.1"
   resolved "http://r.cnpmjs.org/number-is-nan/download/number-is-nan-1.0.1.tgz#097b602b53422a522c1afb8790318336941a011d"


### PR DESCRIPTION
移除对 `npmview` 的依赖 . 使用`node` 原生的模块 `child_process` 的 `exec` 方法进行版本对比

>对于 执行时候 报错： **Request path contains unescaped characters**  
的解决方法为：设置 `npm config set registry http://registry.npmjs.org/` , `https ----> http`  