### PR TITLE
获取首页新碟上架数据以及更新听歌排行

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -105,6 +105,8 @@
 87. 新歌速递
 88. 喜欢音乐列表(无序)
 89. 收藏的 MV 列表
+90. 获取最新专辑
+91. 听歌打卡
 
 ## 安装
 
@@ -1306,6 +1308,26 @@ mp3url 不能直接用 , 可通过 `/song/url` 接口传入歌曲 id 获取具�
 返回数据如下图 :
 
 ![新碟上架](https://raw.githubusercontent.com/Binaryify/NeteaseCloudMusicApi/master/static/new_albums.png)
+
+### 最新专辑
+
+说明 : 调用此接口 ，获取云音乐首页新碟上架数据
+
+**接口地址 :** `/album/newest`
+
+**调用例子 :** `/likelist?uid=32953014`
+
+### 听歌打卡
+
+说明 : 调用此接口 , 传入音乐 id, 来源 id，歌曲时间 time，更新听歌排行数据
+
+**必选参数 :** `id`: 歌曲 id, `sourceid`: 歌单或专辑 id
+
+**可选参数 :** `time`: 歌曲播放时间
+
+**接口地址 :** `/scrobble`
+
+**调用例子 :** `/scrobble?id=482369360&&sourceid=35571977`
 
 ### 热门歌手
 

--- a/module/album_newest.js
+++ b/module/album_newest.js
@@ -1,0 +1,8 @@
+// 最新专辑
+
+module.exports = (query, request) => {
+    return request(
+        'POST', `https://music.163.com/api/discovery/newAlbum`, {},
+        {crypto: 'weapi', cookie: query.cookie, proxy: query.proxy}
+    )
+}

--- a/module/scrobble.js
+++ b/module/scrobble.js
@@ -1,0 +1,22 @@
+// 听歌打卡
+
+module.exports = (query, request) => {
+    const data = {
+        logs: JSON.stringify([{
+            action: 'play',
+            json: {
+                download: 0,
+                end: 'playend',
+                id: query.songid,
+                sourceId: query.sourceid,
+                time: query.time,
+                type: 'song',
+                wifi: 0,
+            }
+        }])
+    }
+    return request(
+        'POST', `https://music.163.com/weapi/feedback/weblog`, data,
+        {crypto: 'weapi', cookie: query.cookie, proxy: query.proxy}
+    )
+}


### PR DESCRIPTION
1. `/top/album`新碟上架与首页数据不一致，新增接口`/album/newest`
2. 包装`/weblog`调用，新增接口`/scrobble`更新听歌记录