### PR TITLE
增加视频标签下的视频获取

### DIFF
--- a/module/video_group.js
+++ b/module/video_group.js
@@ -3,8 +3,7 @@
 module.exports = (query, request) => {
   const data = {
     groupId: query.id,
-    name: query.name,
-    offset: 0,
+    offset: query.offset || 0,
     needUrl: true,
     resolution: query.res || 1080
   }

--- a/module/video_group.js
+++ b/module/video_group.js
@@ -1,0 +1,18 @@
+// 视频链接
+
+module.exports = (query, request) => {
+  const data = {
+    groupId: query.id,
+    name: query.name,
+    offset: 0,
+    needUrl: true,
+    resolution: query.res || 1080
+  }
+  return request(
+    'POST', `https://music.163.com/weapi/videotimeline/videogroup/get`, data, {
+      crypto: 'weapi',
+      cookie: query.cookie,
+      proxy: query.proxy
+    }
+  )
+}


### PR DESCRIPTION
该接口仅在eapi中提供，经测试，可以通过 weapi返回。常见的使用场景: 
1. 根据视频ID获取到videoGroup
2. 根据videoGroupId获取到相关的视频。
（该接口需要登录后才可使用)
具体使用方式: `http://localhost:3000/video/group?id=9104`

