### PR TITLE
默认搜索关键词、单独的歌单名，描述，标签更新

### DIFF
--- a/module/playlist_desc_update.js
+++ b/module/playlist_desc_update.js
@@ -1,0 +1,17 @@
+// 更新歌单描述
+
+module.exports = (query, request) => {
+  const data = {
+    id: query.id,
+    desc: query.desc
+  }
+  return request(
+      'POST', `http://interface3.music.163.com/eapi/playlist/desc/update`, data,
+      {
+        crypto: 'eapi',
+        cookie: query.cookie,
+        proxy: query.proxy,
+        url: '/api/playlist/desc/update'
+      }
+  )
+}

--- a/module/playlist_name_update.js
+++ b/module/playlist_name_update.js
@@ -1,0 +1,17 @@
+// 更新歌单名
+
+module.exports = (query, request) => {
+  const data = {
+    id: query.id,
+    name: query.name
+  }
+  return request(
+      'POST', `http://interface3.music.163.com/eapi/playlist/update/name`, data,
+      {
+        crypto: 'eapi',
+        cookie: query.cookie,
+        proxy: query.proxy,
+        url: '/api/playlist/update/name'
+      }
+  )
+}

--- a/module/playlist_tags_update.js
+++ b/module/playlist_tags_update.js
@@ -1,0 +1,17 @@
+// 更新歌单标签
+
+module.exports = (query, request) => {
+  const data = {
+    id: query.id,
+    tags: query.tags
+  }
+  return request(
+      'POST', `http://interface3.music.163.com/eapi/playlist/tags/update`, data,
+      {
+        crypto: 'eapi',
+        cookie: query.cookie,
+        proxy: query.proxy,
+        url: '/api/playlist/tags/update'
+      }
+  )
+}

--- a/module/search_default.js
+++ b/module/search_default.js
@@ -1,0 +1,14 @@
+// 默认搜索关键词
+
+module.exports = (query, request) => {
+  return request(
+    'POST', `http://interface3.music.163.com/eapi/search/defaultkeyword/get`, {},
+    {
+      crypto: 'eapi',
+      cookie: query.cookie,
+      proxy: query.proxy,
+      url: '/api/search/defaultkeyword/get'
+    }
+  )
+}
+


### PR DESCRIPTION
抓包的时候看到了默认搜索关键词的 API

歌单的信息名和描述都有合法性校验，感觉还是分开来比较好，要是能有头像上传那就非常好了

都是 eapi 的