### PR TITLE
chore: optimize the publishing package for npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,10 @@
     },
     "author": "binaryify",
     "license": "MIT",
+    "files": [
+        "module",
+        "util"
+    ],
     "dependencies": {
         "apicache": "^1.5.2",
         "express": "^4.17.1",


### PR DESCRIPTION
刚才更新的给 nodejs 的发布包可以砍掉一些不必要的内容。
本地可以通过 `npm pack` 预览提供给 npm 发布的 package。