### PR TITLE
更新 TypeScript 声明

### DIFF
--- a/module/send_text.js
+++ b/module/send_text.js
@@ -3,7 +3,6 @@
 module.exports = (query, request) => {
   query.cookie.os = 'pc'
   const data = {
-    id: query.playlist,
     type: 'text',
     msg: query.msg,
     userIds: '[' + query.user_ids + ']',

--- a/module_types/album.d.ts
+++ b/module_types/album.d.ts
@@ -1,5 +1,5 @@
 import { RequestBaseConfig } from './base'
 
 export interface AlbumRequestConfig extends RequestBaseConfig {
-  id: string
+  id: string | number
 }

--- a/module_types/album_detail.d.ts
+++ b/module_types/album_detail.d.ts
@@ -1,5 +1,5 @@
 import { RequestBaseConfig } from './base'
 
 export interface AlbumDetailRequestConfig extends RequestBaseConfig {
-  id: string
+  id: string | number
 }

--- a/module_types/album_detail_dynamic.d.ts
+++ b/module_types/album_detail_dynamic.d.ts
@@ -1,5 +1,5 @@
 import { RequestBaseConfig } from './base'
 
 export interface AlbumDetailDynamicRequestConfig extends RequestBaseConfig {
-  id: string
+  id: string | number
 }

--- a/module_types/album_list.d.ts
+++ b/module_types/album_list.d.ts
@@ -1,8 +1,8 @@
 import { RequestBaseConfig } from './base'
 
 export interface AlbumListRequestConfig extends RequestBaseConfig {
-  limit?: number // 默认 30
-  offset?: number // 默认 0
+  limit?: string | number // 默认 30
+  offset?: string | number // 默认 0
   area?: 'ALL' | 'ZH' | 'EA' | 'KR' | 'JP' // 默认 ALL
   type: string
 }

--- a/module_types/album_list_style.d.ts
+++ b/module_types/album_list_style.d.ts
@@ -1,7 +1,7 @@
 import { RequestBaseConfig } from './base'
 
 export interface AlbumListStyleRequestConfig extends RequestBaseConfig {
-  limit?: number // 默认 10
-  offset?: number // 默认 0
+  limit?: string | number // 默认 10
+  offset?: string | number // 默认 0
   area?: 'Z_H' | 'E_A' | 'KR' | 'JP' // 默认 ALL
 }

--- a/module_types/album_new.d.ts
+++ b/module_types/album_new.d.ts
@@ -1,7 +1,7 @@
 import { RequestBaseConfig } from './base'
 
 export interface AlbumNewRequestConfig extends RequestBaseConfig {
-  limit?: number // 默认 30
-  offset?: number // 默认 0
+  limit?: string | number // 默认 30
+  offset?: string | number // 默认 0
   area?: 'ALL' | 'ZH' | 'EA' | 'KR' | 'JP' // 默认 ALL
 }

--- a/module_types/album_songsaleboard.d.ts
+++ b/module_types/album_songsaleboard.d.ts
@@ -1,7 +1,7 @@
 import { RequestBaseConfig } from './base'
 
 export interface AlbumSongSaleBoardRequestConfig extends RequestBaseConfig {
-  albumType: 0 | 1 // 0 为数字专辑,1 为数字单曲
-  type: 'daily' | 'week' | 'year' | 'total'
+  albumType?: 0 | 1 // 0 为数字专辑,1 为数字单曲
+  type?: 'daily' | 'week' | 'year' | 'total'
   year?: string | number // 年份，默认本年。 type 为 year 时有效
 }

--- a/module_types/album_songsaleboard.d.ts
+++ b/module_types/album_songsaleboard.d.ts
@@ -3,5 +3,5 @@ import { RequestBaseConfig } from './base'
 export interface AlbumSongSaleBoardRequestConfig extends RequestBaseConfig {
   albumType: 0 | 1 // 0 为数字专辑,1 为数字单曲
   type: 'daily' | 'week' | 'year' | 'total'
-  year?: string // 年份，默认本年。 type 为 year 时有效
+  year?: string | number // 年份，默认本年。 type 为 year 时有效
 }

--- a/module_types/album_sub.d.ts
+++ b/module_types/album_sub.d.ts
@@ -1,6 +1,6 @@
 import { RequestBaseConfig } from './base'
 
 export interface AlbumSubRequestConfig extends RequestBaseConfig {
-  id: string
+  id: string | number
   t: 1 | 0
 }

--- a/module_types/album_sublist.d.ts
+++ b/module_types/album_sublist.d.ts
@@ -1,6 +1,6 @@
 import { RequestBaseConfig } from './base'
 
 export interface AlbumSubListRequestConfig extends RequestBaseConfig {
-  limit: number // 默认： 25
-  offset: number // 默认： 0
+  limit: string | number // 默认： 25
+  offset: string | number // 默认： 0
 }

--- a/module_types/artist_album.d.ts
+++ b/module_types/artist_album.d.ts
@@ -1,7 +1,7 @@
 import { RequestBaseConfig } from './base'
 
 export interface ArtistAlbumRequestConfig extends RequestBaseConfig {
-  id: string
-  limit?: number // 默认 30
-  offset?: number // 默认 0
+  id: string | number
+  limit?: string | number // 默认 30
+  offset?: string | number // 默认 0
 }

--- a/module_types/artist_desc.d.ts
+++ b/module_types/artist_desc.d.ts
@@ -1,5 +1,5 @@
 import { RequestBaseConfig } from './base'
 
 export interface ArtistDescRequestConfig extends RequestBaseConfig {
-  id: string
+  id: string | number
 }

--- a/module_types/artist_list.d.ts
+++ b/module_types/artist_list.d.ts
@@ -55,7 +55,7 @@ export interface ArtistListRequestConfig extends RequestBaseConfig {
     | 'X'
     | 'Y'
     | 'Z'
-  offset?: number
-  limit?: number
+  offset?: string | number
+  limit?: string | number
   type?: '1' | '2' | '3'
 }

--- a/module_types/artist_mv.d.ts
+++ b/module_types/artist_mv.d.ts
@@ -1,7 +1,7 @@
 import { RequestBaseConfig } from './base'
 
 export interface ArtistMVRequestConfig extends RequestBaseConfig {
-  artistId: string
-  limit: number
-  offset: number
+  artistId: string | number
+  limit: string | number
+  offset: string | number
 }

--- a/module_types/artist_mv.d.ts
+++ b/module_types/artist_mv.d.ts
@@ -1,7 +1,7 @@
 import { RequestBaseConfig } from './base'
 
 export interface ArtistMVRequestConfig extends RequestBaseConfig {
-  artistId: string | number
+  id: string | number
   limit: string | number
   offset: string | number
 }

--- a/module_types/artist_songs.d.ts
+++ b/module_types/artist_songs.d.ts
@@ -1,8 +1,8 @@
 import { RequestBaseConfig } from './base'
 
 export interface ArtistSongsRequestConfig extends RequestBaseConfig {
-  id: string
+  id: string | number
   order?: 'hot' | 'time'
-  offset?: number
-  limit?: number
+  offset?: string | number
+  limit?: string | number
 }

--- a/module_types/artist_sub.d.ts
+++ b/module_types/artist_sub.d.ts
@@ -1,6 +1,6 @@
 import { RequestBaseConfig } from './base'
 
 export interface ArtistSubRequestConfig extends RequestBaseConfig {
-  artistId: string | number
+  id: string | number
   t: 1 | 0
 }

--- a/module_types/artist_sub.d.ts
+++ b/module_types/artist_sub.d.ts
@@ -1,6 +1,6 @@
 import { RequestBaseConfig } from './base'
 
 export interface ArtistSubRequestConfig extends RequestBaseConfig {
-  artistId: string
+  artistId: string | number
   t: 1 | 0
 }

--- a/module_types/artist_sublist.d.ts
+++ b/module_types/artist_sublist.d.ts
@@ -1,6 +1,6 @@
 import { RequestBaseConfig } from './base'
 
 export interface ArtistSubListRequestConfig extends RequestBaseConfig {
-  limit?: number
-  offset?: number
+  limit?: string | number
+  offset?: string | number
 }

--- a/module_types/artist_top_song.d.ts
+++ b/module_types/artist_top_song.d.ts
@@ -1,5 +1,5 @@
 import { RequestBaseConfig } from './base'
 
 export interface ArtistTopSongRequestConfig extends RequestBaseConfig {
-  id: string
+  id: string | number
 }

--- a/module_types/artists.d.ts
+++ b/module_types/artists.d.ts
@@ -1,5 +1,5 @@
 import { RequestBaseConfig } from './base'
 
 export interface ArtistsRequestConfig extends RequestBaseConfig {
-  id: string
+  id: string | number
 }

--- a/module_types/banner.d.ts
+++ b/module_types/banner.d.ts
@@ -1,5 +1,5 @@
 import { RequestBaseConfig } from './base'
 
 export interface BannerRequestConfig extends RequestBaseConfig {
-  type: 0 | 1 | 2 | 3
+  type?: 0 | 1 | 2 | 3
 }

--- a/module_types/cloudsearch.d.ts
+++ b/module_types/cloudsearch.d.ts
@@ -3,6 +3,6 @@ import { RequestBaseConfig } from './base'
 export interface CloudSearchRequestConfig extends RequestBaseConfig {
   keywords: string
   type: 1 | 10 | 100 | 1000 | 1002 | 1004 | 1006 | 1009 | 1014
-  limit?: number
-  offset?: number
+  limit?: string | number
+  offset?: string | number
 }

--- a/module_types/cloudsearch.d.ts
+++ b/module_types/cloudsearch.d.ts
@@ -2,7 +2,7 @@ import { RequestBaseConfig } from './base'
 
 export interface CloudSearchRequestConfig extends RequestBaseConfig {
   keywords: string
-  type: 1 | 10 | 100 | 1000 | 1002 | 1004 | 1006 | 1009 | 1014
+  type?: 1 | 10 | 100 | 1000 | 1002 | 1004 | 1006 | 1009 | 1014
   limit?: string | number
   offset?: string | number
 }

--- a/module_types/comment.d.ts
+++ b/module_types/comment.d.ts
@@ -1,10 +1,10 @@
 import { RequestBaseConfig } from './base'
 
 export interface CommentRequestConfig extends RequestBaseConfig {
-  id: string
+  id: string | number
   type: 0 | 1 | 2 | 3 | 4 | 5 | 6
   t: 1 | 2 | 0
   threadId?: string
-  content?: string
-  commentId?: string
+  content?: string | number
+  commentId?: string | number
 }

--- a/module_types/comment_album.d.ts
+++ b/module_types/comment_album.d.ts
@@ -1,8 +1,8 @@
 import { RequestBaseConfig } from './base'
 
 export interface CommentAlbumRequestConfig extends RequestBaseConfig {
-  id: string
-  limit?: number
-  offset?: number
-  before?: number
+  id: string | number
+  limit?: string | number
+  offset?: string | number
+  before?: string | number
 }

--- a/module_types/comment_dj.d.ts
+++ b/module_types/comment_dj.d.ts
@@ -1,8 +1,8 @@
 import { RequestBaseConfig } from './base'
 
 export interface CommentDjRequestConfig extends RequestBaseConfig {
-  id: string
-  limit?: number
-  offset?: number
-  before?: number
+  id: string | number
+  limit?: string | number
+  offset?: string | number
+  before?: string | number
 }

--- a/module_types/comment_event.d.ts
+++ b/module_types/comment_event.d.ts
@@ -2,7 +2,7 @@ import { RequestBaseConfig } from './base'
 
 export interface CommentEventRequestConfig extends RequestBaseConfig {
   threadId: string
-  limit?: number
-  offset?: number
-  before?: number
+  limit?: string | number
+  offset?: string | number
+  before?: string | number
 }

--- a/module_types/comment_floor.d.ts
+++ b/module_types/comment_floor.d.ts
@@ -1,9 +1,9 @@
 import { RequestBaseConfig } from './base'
 
 export interface CommentFloorRequestConfig extends RequestBaseConfig {
-  id: string
-  parentCommentId: string
+  id: string | number
+  parentCommentId: string | number
   type: 0 | 1 | 2 | 3 | 4 | 5
-  limit?: number
-  time?: number
+  limit?: string | number
+  time?: string | number
 }

--- a/module_types/comment_hot.d.ts
+++ b/module_types/comment_hot.d.ts
@@ -1,9 +1,9 @@
 import { RequestBaseConfig } from './base'
 
 export interface CommentHotRequestConfig extends RequestBaseConfig {
-  id: string
+  id: string | number
   type: 0 | 1 | 2 | 3 | 4 | 5
-  offset?: number
-  limit?: number
-  before?: number
+  offset?: string | number
+  limit?: string | number
+  before?: string | number
 }

--- a/module_types/comment_like.d.ts
+++ b/module_types/comment_like.d.ts
@@ -1,9 +1,9 @@
 import { RequestBaseConfig } from './base'
 
 export interface CommentLikeRequestConfig extends RequestBaseConfig {
-  id: string
+  id: string | number
   type: 0 | 1 | 2 | 3 | 4 | 5
   t: 1 | 0
-  cid: number
+  cid: string | number
   threadId?: string
 }

--- a/module_types/comment_music.d.ts
+++ b/module_types/comment_music.d.ts
@@ -1,8 +1,8 @@
 import { RequestBaseConfig } from './base'
 
 export interface CommentMusicRequestConfig extends RequestBaseConfig {
-  id: string
-  limit?: number
-  offset?: number
-  before?: number
+  id: string | number
+  limit?: string | number
+  offset?: string | number
+  before?: string | number
 }

--- a/module_types/comment_mv.d.ts
+++ b/module_types/comment_mv.d.ts
@@ -1,8 +1,8 @@
 import { RequestBaseConfig } from './base'
 
 export interface CommentMvRequestConfig extends RequestBaseConfig {
-  id: string
-  limit?: number
-  offset?: number
-  before?: number
+  id: string | number
+  limit?: string | number
+  offset?: string | number
+  before?: string | number
 }

--- a/module_types/comment_playlist.d.ts
+++ b/module_types/comment_playlist.d.ts
@@ -1,8 +1,8 @@
 import { RequestBaseConfig } from './base'
 
 export interface CommentPlaylistRequestConfig extends RequestBaseConfig {
-  id: string
-  limit?: number
-  offset?: number
-  before?: number
+  id: string | number
+  limit?: string | number
+  offset?: string | number
+  before?: string | number
 }

--- a/module_types/comment_video.d.ts
+++ b/module_types/comment_video.d.ts
@@ -1,8 +1,8 @@
 import { RequestBaseConfig } from './base'
 
 export interface CommentVideoRequestConfig extends RequestBaseConfig {
-  id: string
-  limit?: number
-  offset?: number
-  before?: number
+  id: string | number
+  limit?: string | number
+  offset?: string | number
+  before?: string | number
 }

--- a/module_types/daily_signin.d.ts
+++ b/module_types/daily_signin.d.ts
@@ -1,5 +1,5 @@
 import { RequestBaseConfig } from './base'
 
 export interface DailySigninRequestConfig extends RequestBaseConfig {
-  type: 0 | 1
+  type?: 0 | 1
 }

--- a/module_types/digitalAlbum_ordering.d.ts
+++ b/module_types/digitalAlbum_ordering.d.ts
@@ -2,6 +2,6 @@ import { RequestBaseConfig } from './base'
 
 export interface DigitalAlbumOrderingRequestConfig extends RequestBaseConfig {
   payment: string
-  id: string
+  id: string | number
   quantity: string
 }

--- a/module_types/digitalAlbum_purchased.d.ts
+++ b/module_types/digitalAlbum_purchased.d.ts
@@ -1,6 +1,6 @@
 import { RequestBaseConfig } from './base'
 
 export interface DigitalAlbumPurchasedRequestConfig extends RequestBaseConfig {
-  offset?: number
-  limit?: number
+  offset?: string | number
+  limit?: string | number
 }

--- a/module_types/dj_detail.d.ts
+++ b/module_types/dj_detail.d.ts
@@ -1,5 +1,5 @@
 import { RequestBaseConfig } from './base'
 
 export interface DjDetailRequestConfig extends RequestBaseConfig {
-  rid: string
+  rid: string | number
 }

--- a/module_types/dj_hot.d.ts
+++ b/module_types/dj_hot.d.ts
@@ -1,6 +1,6 @@
 import { RequestBaseConfig } from './base'
 
 export interface DjHotRequestConfig extends RequestBaseConfig {
-  offset?: number
-  limit?: number
+  offset?: string | number
+  limit?: string | number
 }

--- a/module_types/dj_paygift.d.ts
+++ b/module_types/dj_paygift.d.ts
@@ -1,6 +1,6 @@
 import { RequestBaseConfig } from './base'
 
 export interface DjPaygiftRequestConfig extends RequestBaseConfig {
-  offset?: number
-  limit?: number
+  offset?: string | number
+  limit?: string | number
 }

--- a/module_types/dj_program.d.ts
+++ b/module_types/dj_program.d.ts
@@ -1,8 +1,8 @@
 import { RequestBaseConfig } from './base'
 
 export interface DjProgramRequestConfig extends RequestBaseConfig {
-  rid: string
-  limit?: number
-  offset?: number
+  rid: string | number
+  limit?: string | number
+  offset?: string | number
   asc: 'true' | 1 | 'false' | 0
 }

--- a/module_types/dj_program_detail.d.ts
+++ b/module_types/dj_program_detail.d.ts
@@ -1,5 +1,5 @@
 import { RequestBaseConfig } from './base'
 
 export interface DjProgramDetailRequestConfig extends RequestBaseConfig {
-  id: number
+  id: string | number
 }

--- a/module_types/dj_program_toplist.d.ts
+++ b/module_types/dj_program_toplist.d.ts
@@ -1,6 +1,6 @@
 import { RequestBaseConfig } from './base'
 
 export interface DjProgramToplistRequestConfig extends RequestBaseConfig {
-  limit?: number
-  offset?: number
+  limit?: string | number
+  offset?: string | number
 }

--- a/module_types/dj_program_toplist_hours.d.ts
+++ b/module_types/dj_program_toplist_hours.d.ts
@@ -1,5 +1,5 @@
 import { RequestBaseConfig } from './base'
 
 export interface DjProgramToplistHoursRequestConfig extends RequestBaseConfig {
-  limit?: number
+  limit?: string | number
 }

--- a/module_types/dj_radio_hot.d.ts
+++ b/module_types/dj_radio_hot.d.ts
@@ -1,7 +1,7 @@
 import { RequestBaseConfig } from './base'
 
 export interface DjRadioHotRequestConfig extends RequestBaseConfig {
-  cateId: string
-  limit?: number
-  offset?: number
+  cateId: string | number
+  limit?: string | number
+  offset?: string | number
 }

--- a/module_types/dj_recommend.d.ts
+++ b/module_types/dj_recommend.d.ts
@@ -1,8 +1,3 @@
 import { RequestBaseConfig } from './base'
 
-export interface DjRecommendRequestConfig extends RequestBaseConfig {
-  rid: string
-  limit?: number
-  offset?: number
-  asc: 0 | 1 | 'true' | 'false'
-}
+export type DjRecommendRequestConfig = RequestBaseConfig

--- a/module_types/dj_sub.d.ts
+++ b/module_types/dj_sub.d.ts
@@ -2,5 +2,5 @@ import { RequestBaseConfig } from './base'
 
 export interface DjSubRequestConfig extends RequestBaseConfig {
   t: 1 | 0
-  rid: string
+  rid: string | number
 }

--- a/module_types/dj_sublist.d.ts
+++ b/module_types/dj_sublist.d.ts
@@ -1,6 +1,6 @@
 import { RequestBaseConfig } from './base'
 
 export interface DjSublistRequestConfig extends RequestBaseConfig {
-  limit?: number
-  offset?: number
+  limit?: string | number
+  offset?: string | number
 }

--- a/module_types/dj_today_perfered.d.ts
+++ b/module_types/dj_today_perfered.d.ts
@@ -1,5 +1,5 @@
 import { RequestBaseConfig } from './base'
 
 export interface DjTodayPerferedRequestConfig extends RequestBaseConfig {
-  page?: number
+  page?: string | number
 }

--- a/module_types/dj_toplist.d.ts
+++ b/module_types/dj_toplist.d.ts
@@ -2,6 +2,6 @@ import { RequestBaseConfig } from './base'
 
 export interface DjToplistRequestConfig extends RequestBaseConfig {
   type: 'new' | 'hot'
-  limit?: number
-  offset?: number
+  limit?: string | number
+  offset?: string | number
 }

--- a/module_types/dj_toplist.d.ts
+++ b/module_types/dj_toplist.d.ts
@@ -1,7 +1,7 @@
 import { RequestBaseConfig } from './base'
 
 export interface DjToplistRequestConfig extends RequestBaseConfig {
-  type: 'new' | 'hot'
+  type?: 'new' | 'hot'
   limit?: string | number
   offset?: string | number
 }

--- a/module_types/dj_toplist_hours.d.ts
+++ b/module_types/dj_toplist_hours.d.ts
@@ -1,5 +1,5 @@
 import { RequestBaseConfig } from './base'
 
 export interface DjToplistHoursRequestConfig extends RequestBaseConfig {
-  limit?: number
+  limit?: string | number
 }

--- a/module_types/dj_toplist_newcomer.d.ts
+++ b/module_types/dj_toplist_newcomer.d.ts
@@ -1,6 +1,6 @@
 import { RequestBaseConfig } from './base'
 
 export interface DjToplistNewcomerRequestConfig extends RequestBaseConfig {
-  limit?: number
-  offset?: number
+  limit?: string | number
+  offset?: string | number
 }

--- a/module_types/dj_toplist_pay.d.ts
+++ b/module_types/dj_toplist_pay.d.ts
@@ -1,5 +1,5 @@
 import { RequestBaseConfig } from './base'
 
 export interface DjToplistPayRequestConfig extends RequestBaseConfig {
-  limit?: number
+  limit?: string | number
 }

--- a/module_types/dj_toplist_popular.d.ts
+++ b/module_types/dj_toplist_popular.d.ts
@@ -1,5 +1,5 @@
 import { RequestBaseConfig } from './base'
 
 export interface DjToplistPopularRequestConfig extends RequestBaseConfig {
-  limit?: number
+  limit?: string | number
 }

--- a/module_types/event_del.d.ts
+++ b/module_types/event_del.d.ts
@@ -1,5 +1,5 @@
 import { RequestBaseConfig } from './base'
 
 export interface EventDelRequestConfig extends RequestBaseConfig {
-  evId?: number
+  evId: string | number
 }

--- a/module_types/event_forward.d.ts
+++ b/module_types/event_forward.d.ts
@@ -2,6 +2,6 @@ import { RequestBaseConfig } from './base'
 
 export interface EventForwardRequestConfig extends RequestBaseConfig {
   forwords: string
-  evId: string
-  uid: string
+  evId: string | number
+  uid: string | number
 }

--- a/module_types/fm_trash.d.ts
+++ b/module_types/fm_trash.d.ts
@@ -1,6 +1,6 @@
 import { RequestBaseConfig } from './base'
 
 export interface FmTrashRequestConfig extends RequestBaseConfig {
-  id: string
-  time?: number
+  id: string | number
+  time?: string | number
 }

--- a/module_types/follow.d.ts
+++ b/module_types/follow.d.ts
@@ -2,5 +2,5 @@ import { RequestBaseConfig } from './base'
 
 export interface FollowRequestConfig extends RequestBaseConfig {
   t: 0 | 1
-  id: string
+  id: string | number
 }

--- a/module_types/homepage_block_page.d.ts
+++ b/module_types/homepage_block_page.d.ts
@@ -1,5 +1,5 @@
 import { RequestBaseConfig } from './base'
 
 export interface HomepageBlockPageRequestConfig extends RequestBaseConfig {
-  refresh: 'true' | 'false'
+  refresh?: 'true' | 'false' | boolean
 }

--- a/module_types/hot_topic.d.ts
+++ b/module_types/hot_topic.d.ts
@@ -1,6 +1,6 @@
 import { RequestBaseConfig } from './base'
 
 export interface HotTopicRequestConfig extends RequestBaseConfig {
-  limit?: number
-  offset?: number
+  limit?: string | number
+  offset?: string | number
 }

--- a/module_types/like.d.ts
+++ b/module_types/like.d.ts
@@ -1,8 +1,8 @@
 import { RequestBaseConfig } from './base'
 
 export interface LikeRequestConfig extends RequestBaseConfig {
-  like?: 'true' | 'false'
-  id: string
+  like?: 'true' | 'false' | boolean
+  id: string | number
   alg?: string
-  time?: number
+  time?: string | number
 }

--- a/module_types/likelist.d.ts
+++ b/module_types/likelist.d.ts
@@ -1,5 +1,5 @@
 import { RequestBaseConfig } from './base'
 
 export interface LikelistRequestConfig extends RequestBaseConfig {
-  uid: string
+  uid: string | number
 }

--- a/module_types/lyric.d.ts
+++ b/module_types/lyric.d.ts
@@ -1,5 +1,5 @@
 import { RequestBaseConfig } from './base'
 
 export interface LyricRequestConfig extends RequestBaseConfig {
-  id: string
+  id: string | number
 }

--- a/module_types/msg_comments.d.ts
+++ b/module_types/msg_comments.d.ts
@@ -1,7 +1,7 @@
 import { RequestBaseConfig } from './base'
 
 export interface MsgCommentsRequestConfig extends RequestBaseConfig {
-  uid: string
-  before?: string
-  limit?: number
+  uid: string | number
+  before?: string | number
+  limit?: string | number
 }

--- a/module_types/msg_forwards.d.ts
+++ b/module_types/msg_forwards.d.ts
@@ -1,6 +1,6 @@
 import { RequestBaseConfig } from './base'
 
 export interface MsgForwardsRequestConfig extends RequestBaseConfig {
-  offset?: number
-  limit?: number
+  offset?: string | number
+  limit?: string | number
 }

--- a/module_types/msg_notices.d.ts
+++ b/module_types/msg_notices.d.ts
@@ -1,6 +1,6 @@
 import { RequestBaseConfig } from './base'
 
 export interface MsgNoticesRequestConfig extends RequestBaseConfig {
-  limit?: number
-  lasttime?: number
+  limit?: string | number
+  lasttime?: string | number
 }

--- a/module_types/msg_private.d.ts
+++ b/module_types/msg_private.d.ts
@@ -1,6 +1,6 @@
 import { RequestBaseConfig } from './base'
 
 export interface MsgPrivateRequestConfig extends RequestBaseConfig {
-  offset?: number
-  limit?: number
+  offset?: string | number
+  limit?: string | number
 }

--- a/module_types/msg_private_history.d.ts
+++ b/module_types/msg_private_history.d.ts
@@ -1,7 +1,7 @@
 import { RequestBaseConfig } from './base'
 
 export interface MsgPrivateHistoryRequestConfig extends RequestBaseConfig {
-  before?: number
-  limit?: number
-  uid: string
+  before?: string | number
+  limit?: string | number
+  uid: string | number
 }

--- a/module_types/mv_all.d.ts
+++ b/module_types/mv_all.d.ts
@@ -4,6 +4,6 @@ export interface MvAllRequestConfig extends RequestBaseConfig {
   area?: string
   type?: string
   order?: string
-  offset?: number
-  limit?: number
+  offset?: string | number
+  limit?: string | number
 }

--- a/module_types/mv_detail.d.ts
+++ b/module_types/mv_detail.d.ts
@@ -1,5 +1,5 @@
 import { RequestBaseConfig } from './base'
 
 export interface MvDetailRequestConfig extends RequestBaseConfig {
-  mvid?: string
+  mvid?: string | number
 }

--- a/module_types/mv_detail_info.d.ts
+++ b/module_types/mv_detail_info.d.ts
@@ -1,5 +1,5 @@
 import { RequestBaseConfig } from './base'
 
 export interface MvDetailInfoRequestConfig extends RequestBaseConfig {
-  mvid: string
+  mvid: string | number
 }

--- a/module_types/mv_exclusive_rcmd.d.ts
+++ b/module_types/mv_exclusive_rcmd.d.ts
@@ -1,6 +1,6 @@
 import { RequestBaseConfig } from './base'
 
 export interface MvExclusiveRcmdRequestConfig extends RequestBaseConfig {
-  offset?: number
-  limit?: number
+  offset?: string | number
+  limit?: string | number
 }

--- a/module_types/mv_first.d.ts
+++ b/module_types/mv_first.d.ts
@@ -2,5 +2,5 @@ import { RequestBaseConfig } from './base'
 
 export interface MvFirstRequestConfig extends RequestBaseConfig {
   area?: string
-  limit?: number
+  limit?: string | number
 }

--- a/module_types/mv_sub.d.ts
+++ b/module_types/mv_sub.d.ts
@@ -2,5 +2,5 @@ import { RequestBaseConfig } from './base'
 
 export interface MvSubRequestConfig extends RequestBaseConfig {
   t: 0 | 1
-  mvid: string
+  mvid: string | number
 }

--- a/module_types/mv_sublist.d.ts
+++ b/module_types/mv_sublist.d.ts
@@ -1,6 +1,6 @@
 import { RequestBaseConfig } from './base'
 
 export interface MvSublistRequestConfig extends RequestBaseConfig {
-  limit?: number
-  offset?: number
+  limit?: string | number
+  offset?: string | number
 }

--- a/module_types/mv_url.d.ts
+++ b/module_types/mv_url.d.ts
@@ -1,6 +1,6 @@
 import { RequestBaseConfig } from './base'
 
 export interface MvUrlRequestConfig extends RequestBaseConfig {
-  id?: string
-  r?: string
+  id?: string | number
+  r?: string | number
 }

--- a/module_types/personalized.d.ts
+++ b/module_types/personalized.d.ts
@@ -1,5 +1,5 @@
 import { RequestBaseConfig } from './base'
 
 export interface PersonalizedRequestConfig extends RequestBaseConfig {
-  limit?: number
+  limit?: string | number
 }

--- a/module_types/personalized_privatecontent_list.d.ts
+++ b/module_types/personalized_privatecontent_list.d.ts
@@ -2,6 +2,6 @@ import { RequestBaseConfig } from './base'
 
 export interface PersonalizedPrivatecontentListRequestConfig
   extends RequestBaseConfig {
-  offset?: number
-  limit?: number
+  offset?: string | number
+  limit?: string | number
 }

--- a/module_types/playlist_delete.d.ts
+++ b/module_types/playlist_delete.d.ts
@@ -1,5 +1,5 @@
 import { RequestBaseConfig } from './base'
 
 export interface PlaylistDeleteRequestConfig extends RequestBaseConfig {
-  id: string
+  id: string | number
 }

--- a/module_types/playlist_desc_update.d.ts
+++ b/module_types/playlist_desc_update.d.ts
@@ -1,6 +1,6 @@
 import { RequestBaseConfig } from './base'
 
 export interface PlaylistDescUpdateRequestConfig extends RequestBaseConfig {
-  id: string
+  id: string | number
   desc: string
 }

--- a/module_types/playlist_detail.d.ts
+++ b/module_types/playlist_detail.d.ts
@@ -1,6 +1,6 @@
 import { RequestBaseConfig } from './base'
 
 export interface PlaylistDetailRequestConfig extends RequestBaseConfig {
-  id: string
-  s?: number
+  id: string | number
+  s?: string | number
 }

--- a/module_types/playlist_name_update.d.ts
+++ b/module_types/playlist_name_update.d.ts
@@ -1,6 +1,6 @@
 import { RequestBaseConfig } from './base'
 
 export interface PlaylistNameUpdateRequestConfig extends RequestBaseConfig {
-  id: string
+  id: string | number
   name: string
 }

--- a/module_types/playlist_order_update.d.ts
+++ b/module_types/playlist_order_update.d.ts
@@ -1,5 +1,5 @@
 import { RequestBaseConfig } from './base'
 
 export interface PlaylistOrderUpdateRequestConfig extends RequestBaseConfig {
-  ids?: string
+  ids: string
 }

--- a/module_types/playlist_subscribe.d.ts
+++ b/module_types/playlist_subscribe.d.ts
@@ -2,5 +2,5 @@ import { RequestBaseConfig } from './base'
 
 export interface PlaylistSubscribeRequestConfig extends RequestBaseConfig {
   t: 0 | 1
-  id: string
+  id: string | number
 }

--- a/module_types/playlist_subscribers.d.ts
+++ b/module_types/playlist_subscribers.d.ts
@@ -1,7 +1,7 @@
 import { RequestBaseConfig } from './base'
 
 export interface PlaylistSubscribersRequestConfig extends RequestBaseConfig {
-  id?: string
-  limit?: number
-  offset?: number
+  id?: string | number
+  limit?: string | number
+  offset?: string | number
 }

--- a/module_types/playlist_tags_update.d.ts
+++ b/module_types/playlist_tags_update.d.ts
@@ -1,6 +1,6 @@
 import { RequestBaseConfig } from './base'
 
 export interface PlaylistTagsUpdateRequestConfig extends RequestBaseConfig {
-  id: string
+  id: string | number
   tags: string
 }

--- a/module_types/playlist_tracks.d.ts
+++ b/module_types/playlist_tracks.d.ts
@@ -2,6 +2,6 @@ import { RequestBaseConfig } from './base'
 
 export interface PlaylistTracksRequestConfig extends RequestBaseConfig {
   op: 'add' | 'del'
-  pid: string
+  pid: string | number
   tracks: string
 }

--- a/module_types/playlist_update.d.ts
+++ b/module_types/playlist_update.d.ts
@@ -1,7 +1,7 @@
 import { RequestBaseConfig } from './base'
 
 export interface PlaylistUpdateRequestConfig extends RequestBaseConfig {
-  id: string
+  id: string | number
   name: string
   desc?: string
   tags?: string

--- a/module_types/playmode_intelligence_list.d.ts
+++ b/module_types/playmode_intelligence_list.d.ts
@@ -2,8 +2,8 @@ import { RequestBaseConfig } from './base'
 
 export interface PlaymodeIntelligenceListRequestConfig
   extends RequestBaseConfig {
-  id: string
-  pid: string
-  sid?: string
-  count?: number
+  id: string | number
+  pid: string | number
+  sid?: string | number
+  count?: string | number
 }

--- a/module_types/program_recommend.d.ts
+++ b/module_types/program_recommend.d.ts
@@ -2,6 +2,6 @@ import { RequestBaseConfig } from './base'
 
 export interface ProgramRecommendRequestConfig extends RequestBaseConfig {
   type: string
-  limit?: number
-  offset?: number
+  limit?: string | number
+  offset?: string | number
 }

--- a/module_types/related_allvideo.d.ts
+++ b/module_types/related_allvideo.d.ts
@@ -1,5 +1,5 @@
 import { RequestBaseConfig } from './base'
 
 export interface RelatedAllvideoRequestConfig extends RequestBaseConfig {
-  id: string
+  id: string | number
 }

--- a/module_types/related_playlist.d.ts
+++ b/module_types/related_playlist.d.ts
@@ -1,5 +1,5 @@
 import { RequestBaseConfig } from './base'
 
 export interface RelatedPlaylistRequestConfig extends RequestBaseConfig {
-  id: string
+  id: string | number
 }

--- a/module_types/resource_like.d.ts
+++ b/module_types/resource_like.d.ts
@@ -3,6 +3,6 @@ import { RequestBaseConfig } from './base'
 export interface ResourceLikeRequestConfig extends RequestBaseConfig {
   t: 0 | 1
   type: 1 | 4 | 5 | 6
-  id?: string
+  id?: string | number
   threadId?: string
 }

--- a/module_types/scrobble.d.ts
+++ b/module_types/scrobble.d.ts
@@ -1,7 +1,7 @@
 import { RequestBaseConfig } from './base'
 
 export interface ScrobbleRequestConfig extends RequestBaseConfig {
-  id: string
-  sourceid: string
-  time: string
+  id: string | number
+  sourceid: string | number
+  time: string | number
 }

--- a/module_types/search.d.ts
+++ b/module_types/search.d.ts
@@ -3,6 +3,6 @@ import { RequestBaseConfig } from './base'
 export interface SearchRequestConfig extends RequestBaseConfig {
   keywords: string
   type?: 1 | 10 | 100 | 1000 | 1002 | 1004 | 1006 | 1009 | 1014
-  limit?: string
-  offset?: string
+  limit?: string | number
+  offset?: string | number
 }

--- a/module_types/send_playlist.d.ts
+++ b/module_types/send_playlist.d.ts
@@ -1,7 +1,7 @@
 import { RequestBaseConfig } from './base'
 
 export interface SendPlaylistRequestConfig extends RequestBaseConfig {
-  playlist: string
+  playlist: string | number
   msg: string
   user_ids: string
 }

--- a/module_types/send_text.d.ts
+++ b/module_types/send_text.d.ts
@@ -2,6 +2,6 @@ import { RequestBaseConfig } from './base'
 
 export interface SendTextRequestConfig extends RequestBaseConfig {
   msg: string
-  id: string
+  id: string | number
   user_ids: string
 }

--- a/module_types/send_text.d.ts
+++ b/module_types/send_text.d.ts
@@ -2,6 +2,5 @@ import { RequestBaseConfig } from './base'
 
 export interface SendTextRequestConfig extends RequestBaseConfig {
   msg: string
-  id: string | number
   user_ids: string
 }

--- a/module_types/share_resource.d.ts
+++ b/module_types/share_resource.d.ts
@@ -3,5 +3,5 @@ import { RequestBaseConfig } from './base'
 export interface ShareResourceRequestConfig extends RequestBaseConfig {
   type?: 'song' | 'playlist' | 'mv' | 'djprogram' | 'djradio'
   msg?: string
-  id?: string
+  id?: string | number
 }

--- a/module_types/simi_artist.d.ts
+++ b/module_types/simi_artist.d.ts
@@ -1,5 +1,5 @@
 import { RequestBaseConfig } from './base'
 
 export interface SimiArtistRequestConfig extends RequestBaseConfig {
-  id: string
+  id: string | number
 }

--- a/module_types/simi_mv.d.ts
+++ b/module_types/simi_mv.d.ts
@@ -1,5 +1,5 @@
 import { RequestBaseConfig } from './base'
 
 export interface SimiMvRequestConfig extends RequestBaseConfig {
-  mvid: string
+  mvid: string | number
 }

--- a/module_types/simi_playlist.d.ts
+++ b/module_types/simi_playlist.d.ts
@@ -1,7 +1,7 @@
 import { RequestBaseConfig } from './base'
 
 export interface SimiPlaylistRequestConfig extends RequestBaseConfig {
-  id: string
-  limit?: number
-  offset?: string
+  id: string | number
+  limit?: string | number
+  offset?: string | number
 }

--- a/module_types/simi_song.d.ts
+++ b/module_types/simi_song.d.ts
@@ -1,7 +1,7 @@
 import { RequestBaseConfig } from './base'
 
 export interface SimiSongRequestConfig extends RequestBaseConfig {
-  id: string
-  limit?: number
-  offset?: number
+  id: string | number
+  limit?: string | number
+  offset?: string | number
 }

--- a/module_types/simi_user.d.ts
+++ b/module_types/simi_user.d.ts
@@ -1,7 +1,7 @@
 import { RequestBaseConfig } from './base'
 
 export interface SimiUserRequestConfig extends RequestBaseConfig {
-  id: string
-  limit?: number
-  offset?: number
+  id: string | number
+  limit?: string | number
+  offset?: string | number
 }

--- a/module_types/song_order_update.d.ts
+++ b/module_types/song_order_update.d.ts
@@ -1,6 +1,6 @@
 import { RequestBaseConfig } from './base'
 
 export interface SongOrderUpdateRequestConfig extends RequestBaseConfig {
-  pid: string
+  pid: string | number
   ids: string
 }

--- a/module_types/song_url.d.ts
+++ b/module_types/song_url.d.ts
@@ -1,6 +1,6 @@
 import { RequestBaseConfig } from './base'
 
 export interface SongUrlRequestConfig extends RequestBaseConfig {
-  id: string
-  br?: number
+  id: string | number
+  br?: string | number
 }

--- a/module_types/top_album.d.ts
+++ b/module_types/top_album.d.ts
@@ -2,8 +2,8 @@ import { RequestBaseConfig } from './base'
 
 export interface TopAlbumRequestConfig extends RequestBaseConfig {
   area?: 'ALL' | 'ZH' | 'EA' | 'KR' | 'JP'
-  limit?: number
-  offset?: number
+  limit?: string | number
+  offset?: string | number
   type?: string
   year?: string
   mouth?: string

--- a/module_types/top_artists.d.ts
+++ b/module_types/top_artists.d.ts
@@ -1,6 +1,6 @@
 import { RequestBaseConfig } from './base'
 
 export interface TopArtistsRequestConfig extends RequestBaseConfig {
-  limit?: string
-  offset?: string
+  limit?: string | number
+  offset?: string | number
 }

--- a/module_types/top_list.d.ts
+++ b/module_types/top_list.d.ts
@@ -1,5 +1,5 @@
 import { RequestBaseConfig } from './base'
 
 export interface TopListRequestConfig extends RequestBaseConfig {
-  id: string
+  id: string | number
 }

--- a/module_types/top_mv.d.ts
+++ b/module_types/top_mv.d.ts
@@ -2,6 +2,6 @@ import { RequestBaseConfig } from './base'
 
 export interface TopMvRequestConfig extends RequestBaseConfig {
   area?: string
-  limit?: number
-  offset?: number
+  limit?: string | number
+  offset?: string | number
 }

--- a/module_types/top_playlist.d.ts
+++ b/module_types/top_playlist.d.ts
@@ -3,6 +3,6 @@ import { RequestBaseConfig } from './base'
 export interface TopPlaylistRequestConfig extends RequestBaseConfig {
   cat?: string
   order?: 'hot' | 'new'
-  limit?: number
-  offset?: number
+  limit?: string | number
+  offset?: string | number
 }

--- a/module_types/top_playlist_highquality.d.ts
+++ b/module_types/top_playlist_highquality.d.ts
@@ -2,6 +2,6 @@ import { RequestBaseConfig } from './base'
 
 export interface TopPlaylistHighqualityRequestConfig extends RequestBaseConfig {
   cat?: string
-  before?: number
-  limit?: number
+  before?: string | number
+  limit?: string | number
 }

--- a/module_types/toplist_artist.d.ts
+++ b/module_types/toplist_artist.d.ts
@@ -1,5 +1,5 @@
 import { RequestBaseConfig } from './base'
 
 export interface ToplistArtistRequestConfig extends RequestBaseConfig {
-  type: number
+  type?: 1 | 2 | 3 | 4
 }

--- a/module_types/user_audio.d.ts
+++ b/module_types/user_audio.d.ts
@@ -1,5 +1,5 @@
 import { RequestBaseConfig } from './base'
 
 export interface UserAudioRequestConfig extends RequestBaseConfig {
-  uid: string
+  uid: string | number
 }

--- a/module_types/user_cloud.d.ts
+++ b/module_types/user_cloud.d.ts
@@ -1,6 +1,6 @@
 import { RequestBaseConfig } from './base'
 
 export interface UserCloudRequestConfig extends RequestBaseConfig {
-  limit?: number
-  offset?: number
+  limit?: string | number
+  offset?: string | number
 }

--- a/module_types/user_cloud_del.d.ts
+++ b/module_types/user_cloud_del.d.ts
@@ -1,5 +1,5 @@
 import { RequestBaseConfig } from './base'
 
 export interface UserCloudDelRequestConfig extends RequestBaseConfig {
-  id: string
+  id: string | number
 }

--- a/module_types/user_cloud_detail.d.ts
+++ b/module_types/user_cloud_detail.d.ts
@@ -1,5 +1,5 @@
 import { RequestBaseConfig } from './base'
 
 export interface UserCloudDetailRequestConfig extends RequestBaseConfig {
-  id: string
+  id: string | number
 }

--- a/module_types/user_detail.d.ts
+++ b/module_types/user_detail.d.ts
@@ -1,5 +1,5 @@
 import { RequestBaseConfig } from './base'
 
 export interface UserDetailRequestConfig extends RequestBaseConfig {
-  uid: string
+  uid: string | number
 }

--- a/module_types/user_dj.d.ts
+++ b/module_types/user_dj.d.ts
@@ -1,7 +1,7 @@
 import { RequestBaseConfig } from './base'
 
 export interface UserDjRequestConfig extends RequestBaseConfig {
-  limit?: number
-  offset?: number
-  uid: string
+  limit?: string | number
+  offset?: string | number
+  uid: string | number
 }

--- a/module_types/user_event.d.ts
+++ b/module_types/user_event.d.ts
@@ -1,7 +1,7 @@
 import { RequestBaseConfig } from './base'
 
 export interface UserEventRequestConfig extends RequestBaseConfig {
-  lasttime?: number
-  limit?: number
-  uid: string
+  lasttime?: string | number
+  limit?: string | number
+  uid: string | number
 }

--- a/module_types/user_followeds.d.ts
+++ b/module_types/user_followeds.d.ts
@@ -1,7 +1,7 @@
 import { RequestBaseConfig } from './base'
 
 export interface UserFollowedsRequestConfig extends RequestBaseConfig {
-  uid: string
-  lasttime?: number
-  limit?: number
+  uid: string | number
+  lasttime?: string | number
+  limit?: string | number
 }

--- a/module_types/user_follows.d.ts
+++ b/module_types/user_follows.d.ts
@@ -1,7 +1,7 @@
 import { RequestBaseConfig } from './base'
 
 export interface UserFollowsRequestConfig extends RequestBaseConfig {
-  uid: string
-  offset?: number
-  limit?: number
+  uid: string | number
+  offset?: string | number
+  limit?: string | number
 }

--- a/module_types/user_playlist.d.ts
+++ b/module_types/user_playlist.d.ts
@@ -1,7 +1,7 @@
 import { RequestBaseConfig } from './base'
 
 export interface UserPlaylistRequestConfig extends RequestBaseConfig {
-  uid: number
-  limit?: number
-  offset?: number
+  uid: string | number
+  limit?: string | number
+  offset?: string | number
 }

--- a/module_types/user_record.d.ts
+++ b/module_types/user_record.d.ts
@@ -1,6 +1,6 @@
 import { RequestBaseConfig } from './base'
 
 export interface UserRecordRequestConfig extends RequestBaseConfig {
-  uid: string
+  uid: string | number
   type: 1 | 0
 }

--- a/module_types/user_record.d.ts
+++ b/module_types/user_record.d.ts
@@ -2,5 +2,5 @@ import { RequestBaseConfig } from './base'
 
 export interface UserRecordRequestConfig extends RequestBaseConfig {
   uid: string | number
-  type: 1 | 0
+  type?: 1 | 0
 }

--- a/module_types/video_category_list.d.ts
+++ b/module_types/video_category_list.d.ts
@@ -1,6 +1,6 @@
 import { RequestBaseConfig } from './base'
 
 export interface VideoCategoryListRequestConfig extends RequestBaseConfig {
-  offset?: number
-  limit?: number
+  offset?: string | number
+  limit?: string | number
 }

--- a/module_types/video_group.d.ts
+++ b/module_types/video_group.d.ts
@@ -2,5 +2,5 @@ import { RequestBaseConfig } from './base'
 
 export interface VideoGroupRequestConfig extends RequestBaseConfig {
   id: string
-  offset?: number
+  offset?: string | number
 }

--- a/module_types/video_timeline_all.d.ts
+++ b/module_types/video_timeline_all.d.ts
@@ -1,5 +1,5 @@
 import { RequestBaseConfig } from './base'
 
 export interface VideoTimelineAllRequestConfig extends RequestBaseConfig {
-  offset?: number
+  offset?: string | number
 }

--- a/module_types/video_timeline_recommend.d.ts
+++ b/module_types/video_timeline_recommend.d.ts
@@ -1,5 +1,5 @@
 import { RequestBaseConfig } from './base'
 
 export interface VideoTimelineRecommendRequestConfig extends RequestBaseConfig {
-  offset?: number
+  offset?: string | number
 }

--- a/module_types/video_url.d.ts
+++ b/module_types/video_url.d.ts
@@ -1,6 +1,6 @@
 import { RequestBaseConfig } from './base'
 
 export interface VideoUrlRequestConfig extends RequestBaseConfig {
-  id: string
+  id: string | number
   res?: number
 }


### PR DESCRIPTION
- 原先的声明里`limit`和`offset`既有`string`又有`number`，现在统一为`string | number`
- 将`id`的类型改为`string | number`（除了`vid`）
- 将提供默认值的参数改为可选
- 修复部分错误的参数名，以及删除不必要的参数