### PR TITLE
修复与 types 文件表现不一致问题

### DIFF
--- a/util/index.js
+++ b/util/index.js
@@ -1,5 +1,6 @@
 module.exports = {
   toBoolean(val) {
+    if (typeof val === 'boolean') return val
     if (val === '') return val
     return val === 'true' || val == '1'
   },


### PR DESCRIPTION
此次更新 types 文件后，对应布尔值的地方允许使用了 type: `boolean`，而接口对布尔参数的处理是调用的 `toBoolean`。
此方法目前只会检查 string ` true` `1`，并不会处理 boolean 类型。
例如： `toBoolean(true) => false`， 因此此 Patch 是对该问题的一个快捷修正