### PR TITLE
解决使用POST请求时cookie没有转换为对象导致的问题

### DIFF
--- a/app.js
+++ b/app.js
@@ -78,9 +78,11 @@ fs.readdirSync(path.join(__dirname, 'module'))
     let question = require(path.join(__dirname, 'module', file))
 
     app.use(route, (req, res) => {
-      if (typeof req.query.cookie === 'string') {
-        req.query.cookie = cookieToJson(req.query.cookie)
-      }
+      ;[req.query, req.body].forEach((item) => {
+        if (typeof item.cookie === 'string') {
+          item.cookie = cookieToJson(decodeURIComponent(item.cookie))
+        }
+      })
       let query = Object.assign(
         {},
         { cookie: req.cookies },

--- a/docs/README.md
+++ b/docs/README.md
@@ -370,7 +370,7 @@ $ sudo docker run -d -p 3000:3000 netease-music-api
 存结果的接口 , 可在请求 url 后面加一个时间戳参数使 url 不同 , 例子 :
 `/simi/playlist?id=347230&timestamp=1503019930000` (之所以加入缓存机制是因为项目早期没有缓存机制，很多  issues 都是报 IP高频，请按自己需求改造缓存中间件(app.js)，源码不复杂)
 
-!> 如果是跨域请求 , 请在所有请求带上 `xhrFields: { withCredentials: true }` (axios 为 `withCredentials: true`)否则
+!> 如果是跨域请求 , 请在所有请求带上 `xhrFields: { withCredentials: true }` (axios 为 `withCredentials: true`, Fetch API 为 `fetch(url, { credentials: 'include' })`), 或直接手动传入cookie (参见 `登录`), 否则
 可能会因为没带上 cookie 导致 301, 具体例子可看 `public/test.html`, 访问`http://localhost:3000/test.html`(默认端口的话) 例子使用 jQuery 和 axios 
 
 !> 301 错误基本都是没登录就调用了需要登录的接口,如果登录了还是提示 301, 基本都是缓存把数据缓存起来了,解决方法是加时间戳或者等待 2 分钟或者重启服务重新登录后再调用接口,可自行改造缓存方法
@@ -430,7 +430,7 @@ $ sudo docker run -d -p 3000:3000 netease-music-api
 完成登录后 , 会在浏览器保存一个 Cookies 用作登录凭证 , 大部分 API 都需要用到这个
 Cookies,非跨域情况请求会自动带上 Cookies,跨域情况参考`调用前须知`
 
-v3.30.0后支持手动传入cookie,登录接口返回内容新增 `cookie` 字段,保存到本地后,get请求带上`?cookie=xxx` 或者 post请求body带上 `cookie` 即可,如:`/user/cloud?cookie=xxx` 或者
+v3.30.0后支持手动传入cookie,登录接口返回内容新增 `cookie` 字段,保存到本地后,get请求带上`?cookie=xxx` (先使用 `encodeURIComponent()` 编码 cookie 值) 或者 post请求body带上 `cookie` 即可,如:`/user/cloud?cookie=xxx` 或者
 ```
 {
     ...,

--- a/module/homepage_dragon_ball.js
+++ b/module/homepage_dragon_ball.js
@@ -4,9 +4,6 @@
 // !需要登录或者匿名登录，非登录返回 []
 const config = require('../util/config.json')
 module.exports = (query, request) => {
-  if (typeof query.cookie === 'string') {
-    query.cookie = cookieToJson(query.cookie)
-  }
   if (!('MUSIC_U' in query.cookie))
     query.cookie.MUSIC_A = config.anonymous_token
   const data = {}

--- a/module/simi_artist.js
+++ b/module/simi_artist.js
@@ -1,9 +1,6 @@
 // 相似歌手
 const config = require('../util/config.json')
 module.exports = (query, request) => {
-  if (typeof query.cookie === 'string') {
-    query.cookie = cookieToJson(query.cookie)
-  }
   if (!('MUSIC_U' in query.cookie))
     query.cookie.MUSIC_A = config.anonymous_token
   const data = {

--- a/module/song_url.js
+++ b/module/song_url.js
@@ -1,11 +1,7 @@
 // 歌曲链接
 
 const crypto = require('crypto')
-const { cookieToJson } = require('../util/index')
 module.exports = (query, request) => {
-  if (typeof query.cookie === 'string') {
-    query.cookie = cookieToJson(query.cookie)
-  }
   if (!('MUSIC_U' in query.cookie))
     query.cookie._ntes_nuid = crypto.randomBytes(16).toString('hex')
   query.cookie.os = 'pc'


### PR DESCRIPTION
1. 在调用模块前，若`req.query.cookie`和`req.body.cookie`是字符串，则先解码，再转为对象。
2. 删除在各模块中的转换。
3. 更新文档。