### PR TITLE
Fix the wrong cookie split regex

### DIFF
--- a/app.js
+++ b/app.js
@@ -41,7 +41,7 @@ app.use((req, res, next) => {
 app.use((req, res, next) => {
   req.cookies = {}
   //;(req.headers.cookie || '').split(/\s*;\s*/).forEach((pair) => { //  Polynomial regular expression //
-  ;(req.headers.cookie || '').split(/^\s+|(?<!\s)\s+$/g).forEach((pair) => {
+  (req.headers.cookie || '').split(/;\s+|(?<!\s)\s+$/g).forEach((pair) => {
     let crack = pair.indexOf('=')
     if (crack < 1 || crack == pair.length - 1) return
     req.cookies[decodeURIComponent(pair.slice(0, crack)).trim()] =


### PR DESCRIPTION
The patched split regex wouldn't handle the given cookie correctly.

Assume given `__remember_me=true; MUSIC_U=aaaaaadddddd; __csrf=ddddddddddd; NMTID=fffffffff` as request cookie, by using `^\s+|(?<!\s)\s+$` it wouldn't contain 3 matches and result 4 entries