### PR TITLE
Better Error Handling for Upload Failure and Max Uploading File Length

### DIFF
--- a/plugins/songUpload.js
+++ b/plugins/songUpload.js
@@ -29,9 +29,12 @@ module.exports = async (query, request) => {
         'Content-Length': String(query.songFile.size),
       },
       data: query.songFile.data,
+      maxContentLength: Infinity,
+      maxBodyLength: Infinity,
     })
   } catch (error) {
     console.log('error', error.response)
+    throw error.response
   }
   return {
     ...tokenRes,


### PR DESCRIPTION
Before:
1. The real upload error will be swallowed
2. The request will fail when music file is greater than 10MB

After:
Both issues are fixed

Test:
`node song_upload.js`