### PR TITLE
refactor: allow using server statically

### DIFF
--- a/main.js
+++ b/main.js
@@ -1,0 +1,34 @@
+const fs = require('fs')
+const path = require('path')
+const { cookieToJson } = require('./util')
+const request = require('./util/request')
+
+/** @type {Record<string, any>} */
+let obj = {}
+fs.readdirSync(path.join(__dirname, 'module'))
+  .reverse()
+  .forEach((file) => {
+    if (!file.endsWith('.js')) return
+    let fileModule = require(path.join(__dirname, 'module', file))
+    let fn = file.split('.').shift() || ''
+    obj[fn] = function (data) {
+      if (typeof data.cookie === 'string') {
+        data.cookie = cookieToJson(data.cookie)
+      }
+      return fileModule(
+        {
+          ...data,
+          cookie: data.cookie ? data.cookie : {},
+        },
+        request,
+      )
+    }
+  })
+
+/**
+ * @type {Record<string, any> & import("./server")}
+ */
+module.exports = {
+  ...require('./server'),
+  ...obj,
+}

--- a/main.test.js
+++ b/main.test.js
@@ -1,0 +1,18 @@
+const assert = require('assert')
+const main = require('./main')
+
+describe('methods in server.js', () => {
+  it('has serveNcmApi', () => {
+    assert.strictEqual(typeof main.serveNcmApi, 'function')
+  })
+
+  it('has getModulesDefinitions', () => {
+    assert.strictEqual(typeof main.getModulesDefinitions, 'function')
+  })
+})
+
+describe('methods in module', () => {
+  it('has activate_init_profile', () => {
+    assert.strictEqual(typeof main.activate_init_profile, 'function')
+  })
+})

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "网易云音乐 NodeJS 版 API",
   "scripts": {
     "start": "node app.js",
-    "test": "mocha -r intelli-espower-loader -t 20000 server.test.js --exit",
+    "test": "mocha -r intelli-espower-loader -t 20000 server.test.js main.test.js --exit",
     "lint": "eslint \"**/*.{js,ts}\"",
     "lint-fix": "eslint --fix \"**/*.{js,ts}\"",
     "prepare": "husky install",
@@ -26,7 +26,7 @@
     "音乐",
     "网易云音乐nodejs"
   ],
-  "main": "server.js",
+  "main": "main.js",
   "types": "./interface.d.ts",
   "engines": {
     "node": ">=12"

--- a/server.js
+++ b/server.js
@@ -294,28 +294,7 @@ async function serveNcmApi(options) {
   return appExt
 }
 
-let obj = {}
-fs.readdirSync(path.join(__dirname, 'module'))
-  .reverse()
-  .forEach((file) => {
-    if (!file.endsWith('.js')) return
-    let fileModule = require(path.join(__dirname, 'module', file))
-    obj[file.split('.').shift()] = function (data) {
-      if (typeof data.cookie === 'string') {
-        data.cookie = cookieToJson(data.cookie)
-      }
-      return fileModule(
-        {
-          ...data,
-          cookie: data.cookie ? data.cookie : {},
-        },
-        request,
-      )
-    }
-  })
-
 module.exports = {
   serveNcmApi,
   getModulesDefinitions,
-  ...obj,
 }


### PR DESCRIPTION
將原本 "NeteaseCloudMusicApi/server" 掃描 modules 目錄的部分抽出 server.js，
改移到 main.js。這樣使用者就有辦法只載入靜態的伺服器部分（不動態載入模組）。

這個 patch 的 breaking changes 不易發生。可作為 patch version 發佈。