### PR TITLE
fix: add "server.js" to the filelist to pack

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,8 @@
     "plugins",
     "main.d.ts",
     "interface.d.ts",
-    "module_types"
+    "module_types",
+    "server.js"
   ],
   "dependencies": {
     "axios": "^0.24.0",


### PR DESCRIPTION
目前的 NPM 包少了 server.js，會導致 "NeteaseCloudMusicApi/server" 找不到檔案，也會讓 `npx NeteaseCloudMusicApi` 報錯（找不到 server.js 模組）