### PR TITLE
fix: 部署在域名子路径下无法执行示例的问题

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -14,9 +14,9 @@
   <a href="https://neteasecloudmusicapi.vercel.app">查看文档</a>
   <h2>例子:</h2>
   <ul>
-    <li>1. <a href="/search?keywords=海阔天空">搜索</a></li>
-    <li>2. <a href="/comment/music?id=186016&limit=1">歌曲评论</a></li>
-    <li>3. <a href="/dj/program?rid=336355127">电台节目</a></li>
+    <li>1. <a href="./search?keywords=海阔天空">搜索</a></li>
+    <li>2. <a href="./comment/music?id=186016&limit=1">歌曲评论</a></li>
+    <li>3. <a href="./dj/program?rid=336355127">电台节目</a></li>
   </ul>
   <style>
     html,


### PR DESCRIPTION
Vercel部署，Nginx反代到子路径下。
部署在https://meedfine.com/music-api/ 
原代码会导致首页示例调用到 错误路径 https://meedfine.com/comment/music?id=186016&limit=1   404
调整后正常：https://meedfine.com/music-api/comment/music?id=186016&limit=1
调整成 根路径与子路径都支持