### PR TITLE
Dockerfile 重构

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,10 @@
+/**
+!/module
+!/plugins
+!/public
+!/static
+!/util
+!/app.js
+!/server.js
+!/package.json
+!/package-lock.json

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,16 @@
 FROM node:lts-alpine
 
-WORKDIR /app
-COPY . /app
+RUN apk add --no-cache tini
 
-RUN npm config set registry "https://registry.npmmirror.com/" \
-    && npm install -g npm husky \
-    && npm install --production
+ENV NODE_ENV production
+USER node
+
+WORKDIR /app
+
+COPY --chown=node:node . ./
+
+RUN npm i --omit=dev --ignore-scripts
 
 EXPOSE 3000
-CMD ["node", "app.js"]
+
+CMD [ "/sbin/tini", "--", "node", "app.js" ]


### PR DESCRIPTION
目前的 Dockerfile 有如下几个问题：
1. `COPY` 命令复制了全部源码，很多是在实际 Docker 运行中用不到的，会增加镜像体积
2. `npm config set registry` 应该是不需要的，使用 github action 打包镜像时 npm install 速度足够快
3. `npm i --omit=dev --ignore-scripts` 可以替换 `npm install -g husky && npm install --production`
4. **严重问题：** 使用 `CMD ["node", "app.js"]` 会导致 nodejs 无法及时响应操作系统传递的信号，具体表现为执行 `docker stop` 命令停止容器时耗时很久，可以参考 https://dev.to/nodepractices/docker-best-practices-with-node-js-4ln4

重构后的 Dockerfile 有如下提升：
1. 镜像体积在 dockerhub 由原来的 76.23M 缩减为 56.33M
2. 可以瞬时响应 `docker stop` 命令

注意：`.dockerignore` 文件中以 `!/` 开头的文件代表了会拷贝进 Docker 镜像的文件（更好的做法是重新调整源码目录结构，比如增加 src 目录，这样编写 Dockerfile 会更简洁）