### PR TITLE
fix: axios is not a function when using ES module

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "NeteaseCloudMusicApi",
-  "version": "4.8.2",
+  "version": "4.8.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "NeteaseCloudMusicApi",
-      "version": "4.8.2",
+      "version": "4.8.7",
       "license": "MIT",
       "dependencies": {
-        "axios": "^1.0.0",
+        "axios": "^1.2.2",
         "express": "^4.17.1",
         "express-fileupload": "^1.1.9",
         "md5": "^2.3.0",
@@ -830,9 +830,9 @@
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
     },
     "node_modules/axios": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.1.3.tgz",
-      "integrity": "sha512-00tXVRwKx/FZr/IDVFt4C+f9FYairX517WoGCL6dpOntqLkZofjhu43F/Xl44UOpqa+9sLFDrG/XAnFsUYgkDA==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmmirror.com/axios/-/axios-1.2.2.tgz",
+      "integrity": "sha512-bz/J4gS2S3I7mpN/YZfGFTqhXTYzRho8Ay38w2otuuDR322KzFIWm/4W2K6gIwvWaws5n+mnb7D1lN9uD+QH6Q==",
       "dependencies": {
         "follow-redirects": "^1.15.0",
         "form-data": "^4.0.0",
@@ -6464,9 +6464,9 @@
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
     },
     "axios": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.1.3.tgz",
-      "integrity": "sha512-00tXVRwKx/FZr/IDVFt4C+f9FYairX517WoGCL6dpOntqLkZofjhu43F/Xl44UOpqa+9sLFDrG/XAnFsUYgkDA==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmmirror.com/axios/-/axios-1.2.2.tgz",
+      "integrity": "sha512-bz/J4gS2S3I7mpN/YZfGFTqhXTYzRho8Ay38w2otuuDR322KzFIWm/4W2K6gIwvWaws5n+mnb7D1lN9uD+QH6Q==",
       "requires": {
         "follow-redirects": "^1.15.0",
         "form-data": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "public"
   ],
   "dependencies": {
-    "axios": "^1.0.0",
+    "axios": "^1.2.2",
     "express": "^4.17.1",
     "express-fileupload": "^1.1.9",
     "md5": "^2.3.0",

--- a/util/request.js
+++ b/util/request.js
@@ -1,6 +1,6 @@
 const encrypt = require('./crypto')
 const crypto = require('crypto')
-const axios = require('axios')
+const { default: axios } = require('axios')
 const PacProxyAgent = require('pac-proxy-agent')
 const http = require('http')
 const https = require('https')


### PR DESCRIPTION
在一个使用 ESM 的 Electron 项目上，运行时报错 axios is not a function

然后发现在[这个 commit](https://github.com/Binaryify/NeteaseCloudMusicApi/commit/23516ca856270ad04871399e1d4c494f07901780#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519) 里将 axios 的版本升级到了 1.0.0，在 axios 新版本的文档上提到过 CommonJS 中可以使用这种写法来导入：
```
const axios = require('axios').default
``` 
实测这样导入可以解决 ESM 中的问题。如果直接转换成 ESM，导入的 axios 就成了一个 module，没办法直接作为函数使用，而使用里面默认导出的 default 函数就可以了。

另外 `const { default: axios } = require('axios')` 也等价于上面的写法，这样写只是为了美观一点。