### PR TITLE
docs: document `yrc` lyrics

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1671,6 +1671,35 @@ tags: 歌单标签
 
 相关讨论可见: [Issue](https://github.com/Binaryify/NeteaseCloudMusicApi/issues/1667)
 
+**歌词格式解析 :**
+
+当逐字歌词适用时，`yrc`的`lyric`字段包括形式如下的内容
+* （可能存在）JSON 歌曲元数据
+```
+{"t":0,"c":[{"tx":"作曲: "},{"tx":"柳重言","li":"http://p1.music.126.net/Icj0IcaOjH2ZZpyAM-QGoQ==/6665239487822533.jpg","or":"orpheus://nm/artist/home?id=228547&type=artist"}]}
+{"t":5403,"c":[{"tx":"编曲: "},{"tx":"Alex San","li":"http://p1.music.126.net/pSbvYkrzZ1RFKqoh-fA9AQ==/109951166352922615.jpg","or":"orpheus://nm/artist/home?id=28984845&type=artist"}]}
+{"t":10806,"c":[{"tx":"制作人: "},{"tx":"王菲","li":"http://p1.music.126.net/1KQVD6XWbs5IAV0xOj1ZIA==/18764265441342019.jpg","or":"orpheus://nm/artist/home?id=9621&type=artist"},{"tx":"/"},{"tx":"梁荣骏","li":"http://p1.music.126.net/QrD8drwrRcegfKLPoiiG2Q==/109951166288436155.jpg","or":"orpheus://nm/artist/home?id=189294&type=artist"}]}
+```
+该字段不一定出现；可能出现的数据意义有：
+- `t` : 数据显示开始时间戳 (毫秒)
+- `c` : 元数据list
+- `tx`: 文字段
+- `li`: 艺术家、歌手头像图url
+- `or`：云音乐app内路径；例中作用即打开艺术家主页
+* 逐字歌词
+```
+[16210,3460](16210,670,0)还(16880,410,0)没...
+ ~~~~1 ~~~2  ~~~~3 ~~4 5 ~6 (...) 
+```
+由标号解释:
+1. 歌词行显示开始时间戳 (毫秒)
+2. 歌词行显示总时长(毫秒)
+3. 逐字显示开始时间戳 (毫秒)
+4. 逐字显示时长 (厘秒/0.01s)
+5. 未知
+6. 文字
+
+`yrc`的`version`字段貌似与`lyric`字段格式无关
 
 ### 新歌速递
 


### PR DESCRIPTION
加入对新歌词接口 `/song/lyric/v1` 中 `yrc` 字段的解释

同时[`pyncm`中也有相关impl](https://github.com/mos9527/pyncm/blob/master/pyncm/utils/yrcparser.py)以`ass`格式输出卡拉ok式歌词。写的有点难看就没加在README里了🫤