### PR TITLE
compatibility with Deno

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "NeteaseCloudMusicApi",
-  "version": "4.10.1",
+  "version": "4.12.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -733,6 +733,11 @@
       "version": "5.0.3",
       "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.0.3.tgz",
       "integrity": "sha512-QHX8HLlncOLpy54mh+k/sWIFd0ThmRqwe9ZjELybGZK+tZ8rUb9VO0saKJUROTbE+KhzDUT7xziGpGrW8Kmd+g=="
+    },
+    "bigint-mod-arith": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/bigint-mod-arith/-/bigint-mod-arith-3.3.1.tgz",
+      "integrity": "sha512-pX/cYW3dCa87Jrzv6DAr8ivbbJRzEX5yGhdt8IutnX/PCIXfpx+mabWNK/M8qqh+zQ0J3thftUBHW0ByuUlG0w=="
     },
     "binary-extensions": {
       "version": "2.2.0",

--- a/package.json
+++ b/package.json
@@ -8,9 +8,9 @@
     "lint": "eslint \"**/*.{js,ts}\"",
     "lint-fix": "eslint --fix \"**/*.{js,ts}\"",
     "prepare": "husky install",
-    "pkgwin": "pkg . -t node14-win-x64 -C GZip -o bin/app --no-bytecode",
-    "pkglinux": "pkg . -t node14-linux-x64 -C GZip -o bin/app --no-bytecode",
-    "pkgmacos": "pkg . -t node14-macos-x64 -C GZip -o bin/app --no-bytecode"
+    "pkgwin": "pkg . -t node16-win-x64 -C GZip -o bin/app --no-bytecode",
+    "pkglinux": "pkg . -t node16-linux-x64 -C GZip -o bin/app --no-bytecode",
+    "pkgmacos": "pkg . -t node16-macos-x64 -C GZip -o bin/app --no-bytecode"
   },
   "bin": "./app.js",
   "pkg": {
@@ -41,7 +41,7 @@
   "main": "main.js",
   "types": "./interface.d.ts",
   "engines": {
-    "node": ">=12"
+    "node": ">=16"
   },
   "lint-staged": {
     "*.js": [
@@ -64,6 +64,7 @@
   ],
   "dependencies": {
     "axios": "^1.2.2",
+    "bigint-mod-arith": "^3.3.1",
     "express": "^4.17.1",
     "express-fileupload": "^1.1.9",
     "md5": "^2.3.0",

--- a/util/crypto.js
+++ b/util/crypto.js
@@ -1,10 +1,16 @@
 const crypto = require('crypto')
+const { modPow } = require('bigint-mod-arith')
 const iv = Buffer.from('0102030405060708')
 const presetKey = Buffer.from('0CoJUm6Qyw8W8jud')
 const linuxapiKey = Buffer.from('rFgB&h#%2?^eDg:Q')
 const base62 = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789'
 const publicKey =
-  '-----BEGIN PUBLIC KEY-----\nMIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDgtQn2JZ34ZC28NWYpAUd98iZ37BUrX/aKzmFbt7clFSs6sXqHauqKWqdtLkF2KexO40H1YTX8z2lSgBBOAxLsvaklV8k4cBFK9snQXE9/DDaFt6Rr7iVZMldczhC0JNgTz+SHXT6CBHuX3e9SdB1Ua44oncaTWz7OBGLbCiK45wIDAQAB\n-----END PUBLIC KEY-----'
+  '-----BEGIN PUBLIC KEY-----\n' +
+  'MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDgtQn2JZ34ZC28NWYpAUd98iZ3\n' +
+  '7BUrX/aKzmFbt7clFSs6sXqHauqKWqdtLkF2KexO40H1YTX8z2lSgBBOAxLsvakl\n' +
+  'V8k4cBFK9snQXE9/DDaFt6Rr7iVZMldczhC0JNgTz+SHXT6CBHuX3e9SdB1Ua44o\n' +
+  'ncaTWz7OBGLbCiK45wIDAQAB\n' +
+  '-----END PUBLIC KEY-----'
 const eapiKey = 'e82ckenh8dichen8'
 
 const aesEncrypt = (buffer, mode, key, iv) => {
@@ -13,18 +19,28 @@ const aesEncrypt = (buffer, mode, key, iv) => {
 }
 
 const rsaEncrypt = (buffer, key) => {
+  const base = BigInt('0x' + Buffer.from(buffer).toString('hex'))
+  const pubKey = crypto.createPublicKey(key).export({ format: 'jwk' })
+  const modulus = BigInt('0x' + Buffer.from(pubKey.n, 'base64').toString('hex'))
+  const exponent = BigInt(
+    '0x' + Buffer.from(pubKey.e, 'base64').toString('hex'),
+  )
+  const result = modPow(base, exponent, modulus).toString(16)
+  return result.padStart(256, '0')
+  /* original, using crypto.publicEncrypt() with RSA_NO_PADDING:
   buffer = Buffer.concat([Buffer.alloc(128 - buffer.length), buffer])
   return crypto.publicEncrypt(
     { key: key, padding: crypto.constants.RSA_NO_PADDING },
     buffer,
-  )
+  ).toString('hex')
+  */
 }
 
 const weapi = (object) => {
   const text = JSON.stringify(object)
   const secretKey = crypto
     .randomBytes(16)
-    .map((n) => base62.charAt(n % 62).charCodeAt())
+    .map((n) => base62.charAt(n % 62).charCodeAt(0))
   return {
     params: aesEncrypt(
       Buffer.from(
@@ -34,7 +50,7 @@ const weapi = (object) => {
       secretKey,
       iv,
     ).toString('base64'),
-    encSecKey: rsaEncrypt(secretKey.reverse(), publicKey).toString('hex'),
+    encSecKey: rsaEncrypt(secretKey.reverse(), publicKey),
   }
 }
 


### PR DESCRIPTION
This PR adds compatibility with [Deno](https://deno.com/). It allows at least the API to be imported into a Deno application (not the server part based on express, though).

For the Deno compatibility I had to change the following things:

1. In `crypto.js`: replace `crypto.publicEncrypt(..., RSA_NO_PADDING)` which alas is not available in Deno.
   I replaced it with a custom RSA implementation which does the same.
2. The RSA `publicKey` in `crypto.js` changed to have a line-length of 64 chars. Deno (or rather, it's Rust-based backend) doesn't like long-lined public keys, which is not a standard anyways.
3. I extract the modulus and exponent from the RSA public key using `crypto.createPublicKey(key).export({ format: 'jwk' })`. This function is available in Node.js 16.x or higher. Therefore the requirements for this PR rise from Node.js 12.x to 16.x. I hope this is ok. If you don't agree I can find another alternative.
4. I added a new dependency bigint-mod-arith for the RSA modPow() function. This is pretty uncritical.

I carefully checked that the changed crypto functions produce exactly the same binary data as before.

I tested with Node.js 16.x, 20.x and Deno. Everything seems to work as usual, so if you agree I think this can be integrated into the master branch. :)