### PR TITLE
Fix: 使用 Node 调用 song_url 时未正确处理 number 类型

### DIFF
--- a/module/song_url.js
+++ b/module/song_url.js
@@ -1,7 +1,7 @@
 // 歌曲链接
 module.exports = async (query, request) => {
   query.cookie.os = 'pc'
-  const ids = query.id.split(',')
+  const ids = String(query.id).split(',')
   const data = {
     ids: JSON.stringify(ids),
     br: parseInt(query.br || 999000),


### PR DESCRIPTION
修复了使用 Node.js 调用 song_url 时，如 `id` 参数传入类型为 `number` 时，则会发生的错误：

```
TypeError: query.id.split is not a function
```