### PR TITLE
ci: Use GITHUB_OUTPUT envvar instead of set-output command

### DIFF
--- a/.github/workflows/Build_Image.yml
+++ b/.github/workflows/Build_Image.yml
@@ -17,7 +17,7 @@ jobs:
           - name: Get version
             id: get_version
             if: startsWith(github.ref, 'refs/tags/') && startsWith(github.repository, 'Binaryify/NeteaseCloudMusicApi')
-            run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\//}
+            run: echo "VERSION=${GITHUB_REF/refs\/tags\//}" >> $GITHUB_OUTPUT
           - name: Set up Docker Buildx
             uses: docker/setup-buildx-action@v2
           - name: Build and publish image


### PR DESCRIPTION
`save-state` and `set-output` commands used in GitHub Actions are deprecated and [GitHub recommends using environment files](https://github.blog/changelog/2023-07-24-github-actions-update-on-save-state-and-set-output-commands/).

This PR updates the usage of `set-output` to `$GITHUB_OUTPUT`

Instructions for envvar usage from GitHub docs:

https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter


